### PR TITLE
feat: fix logger prefix, update sample config paths, and implement SEA detection

### DIFF
--- a/constants/configschema.js
+++ b/constants/configschema.js
@@ -10,6 +10,7 @@ const resolvedConfig = {
     targetPlatform: null,
     target: null,
     arch: "x64",
+    buildType: "standard",
     assets: {},
     metadata: {},
     paths: {}

--- a/index.js
+++ b/index.js
@@ -1,28 +1,26 @@
+#!/usr/bin/env node
 
 const logger = require("./utils/logger");
 const resolveConfig = require("./lib/configresolver");
 
 const args = process.argv.slice(2);
-
-const target = args[0];
+const separatorIndex = args.indexOf('--');
+const passedFlags = separatorIndex !== -1 ? args.slice(0, separatorIndex) : args;
+const neuBuildFlags = separatorIndex !== -1 ? args.slice(separatorIndex + 1) : [];
+const target = passedFlags.find(arg => !arg.startsWith('-'));
 
 logger.info("Neutralinojs Builder initialized.");
 
 const config = resolveConfig();
+config.neuBuildFlags = neuBuildFlags;
 
 logger.info("Configuration loaded.");
 
-console.log(config);
-
 if (!target) {
-
-    logger.warn(
-        "No target specified. Usage: neu-builder <target>"
-    );
-
-}
-else {
-
+    logger.warn("No target specified. Usage: neu-builder <target> -- [neu build flags]");
+} else {
     logger.info(`Target detected: ${target}`);
-
+    if (neuBuildFlags.length > 0) {
+        logger.info(`Neu build flags detected: ${neuBuildFlags.join(' ')}`);
+    }
 }

--- a/lib/buildinvoker.js
+++ b/lib/buildinvoker.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+const logger = require('../utils/logger');
+
+let detectBuildType = (projectPath) => {
+    const resourcesPath = path.join(projectPath, 'resources.neu');
+    return fs.existsSync(resourcesPath) ? 'standard' : 'sea';
+};
+
+let prepare = (resolvedConfig) => {
+    const projectPath = process.cwd();
+    const buildType = detectBuildType(projectPath);
+    logger.info(`Build type detected: ${buildType}`);
+    resolvedConfig.buildType = buildType;
+    return resolvedConfig;
+};
+
+module.exports = {
+    detectBuildType,
+    prepare
+};

--- a/lib/configresolver.js
+++ b/lib/configresolver.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const {
     cliOptions,
     resolvedConfig: resolvedConfigTemplate
-} = require("../constants/config-schema");
+} = require("../constants/configschema");
 
 function resolveConfig() {
 

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -13,10 +13,10 @@
               "x64",
               "ia32"
             ],
-            "icon": "/assets/windows/app.ico",
-            "sidebarImage": "/assets/windows/sidebar.bmp",
-            "headerImage": "/assets/windows/header.bmp",
-            "license": "/assets/LICENSE.txt",
+            "icon": "/installerassets/windows/nsis/app.ico",
+            "sidebarImage": "/installerassets/windows/nsis/sidebar.bmp",
+            "headerImage": "/installerassets/windows/nsis/header.bmp",
+            "license": "/installerassets/LICENSE.txt",
             "output": "/dist/windows"
           }
         ]
@@ -30,8 +30,8 @@
               "ia32",
               "armhf"
             ],
-            "icon": "/assets/linux/app.png",
-            "desktopEntry": "/assets/linux/myapp.desktop",
+            "icon": "/installerassets/linux/deb/app.png",
+            "desktopEntry": "/installerassets/linux/deb/myapp.desktop",
             "category": "Utility",
             "output": "/dist/linux"
           },
@@ -41,9 +41,9 @@
               "x64",
               "arm64"
             ],
-            "icon": "/assets/linux/app.png",
-            "desktopEntry": "/assets/linux/myapp.desktop",
-            "license": "/assets/LICENSE.txt",
+            "icon": "/installerassets/linux/appimage/app.png",
+            "desktopEntry": "/installerassets/linux/appimage/myapp.desktop",
+            "license": "/installerassets/LICENSE.txt",
             "output": "/dist/linux"
           }
         ]
@@ -57,8 +57,8 @@
               "arm64",
               "universal"
             ],
-            "icon": "/assets/mac/app.icns",
-            "background": "/assets/mac/dmg-background.png",
+            "icon": "/installerassets/mac/dmg/app.icns",
+            "background": "/installerassets/mac/dmg/dmg-background.png",
             "output": "/dist/mac"
           }
         ]

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -2,12 +2,12 @@ const chalk = require('chalk');
 
 const formatMsg = (msg) => typeof msg === 'object' ? JSON.stringify(msg, null, 2) : msg;
 
-let info = (msg) => console.log(`neu: ${chalk.bgGreen.black('INFO')} ${formatMsg(msg)}`);
-let warn = (msg) => console.warn(`neu: ${chalk.bgYellow.black('WARN')} ${formatMsg(msg)}`);
-let error = (msg) => console.error(`neu: ${chalk.bgRed.black('ERRR')} ${formatMsg(msg)}`);
+let info = (msg) => console.log(`neu-builder: ${chalk.bgGreen.black('INFO')} ${formatMsg(msg)}`);
+let warn = (msg) => console.warn(`neu-builder: ${chalk.bgYellow.black('WARN')} ${formatMsg(msg)}`);
+let error = (msg) => console.error(`neu-builder: ${chalk.bgRed.black('ERRR')} ${formatMsg(msg)}`);
 let debug = (msg) => {
     if (process.env.DEBUG) {
-        console.log(`neu: ${chalk.bgMagenta.white('DEBG')} ${formatMsg(msg)}`);
+        console.log(`neu-builder: ${chalk.bgMagenta.white('DEBG')} ${formatMsg(msg)}`);
     }
 };
 


### PR DESCRIPTION
****

This PR implements build type detection inside lib/buildinvoker.js to automatically determine if the application is running a standard build or SEA (Single Executable Archive) mode based on the presence of resources.neu. It also fixes the console logger prefix by updating it from neu: to neu-builder: in utils/logger.js, and corrects the asset targets inside neutralino.config.json to utilize target-specific directories under /installerassets/


****