### PR TITLE
feat: add builder pipeline, staging manager, target loader and test suite

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,32 +2,30 @@
 
 const logger = require("./utils/logger");
 const resolveConfig = require("./lib/configresolver");
-const precheck = require("./lib/precheck")
+const builder = require("./lib/builder");
+
 const args = process.argv.slice(2);
 const separatorIndex = args.indexOf('--');
 const passedFlags = separatorIndex !== -1 ? args.slice(0, separatorIndex) : args;
 const neuBuildFlags = separatorIndex !== -1 ? args.slice(separatorIndex + 1) : [];
 const target = passedFlags.find(arg => !arg.startsWith('-'));
+
 logger.info("Neutralinojs Builder initialized.");
 
 const config = resolveConfig();
 config.neuBuildFlags = neuBuildFlags;
 
-logger.info("Configuration loaded.");
-
 if (!target) {
     logger.warn("No target specified. Usage: neu-builder <target> -- [neu build flags]");
+    process.exit(1);
 } else {
-    logger.info(`Target detected: ${target}`);
+    config.target = target;
+    logger.info("Configuration loaded.");
+    logger.info(`Target platform detected: ${target}`);
     if (neuBuildFlags.length > 0) {
-        logger.info(`Neu build flags detected: ${neuBuildFlags.join(' ')}`);
+        logger.info(`Forwarding core build flags: ${neuBuildFlags.join(' ')}`);
     }
-}
-
-const precheckRes = precheck(config);
-if (precheck) {
-    logger.info("Precheck Stage Passed.");
-}
-else {
-    logger.info("Precheck Stage Failed.");
+    builder.build(config).catch(() => {
+        process.exit(1);
+    });
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 const logger = require("./utils/logger");
-const resolveConfig = require("./lib/configresolver");
 const builder = require("./lib/builder");
 
 const args = process.argv.slice(2);
@@ -12,20 +11,15 @@ const target = passedFlags.find(arg => !arg.startsWith('-'));
 
 logger.info("Neutralinojs Builder initialized.");
 
-const config = resolveConfig();
-config.neuBuildFlags = neuBuildFlags;
-
 if (!target) {
     logger.warn("No target specified. Usage: neu-builder <target> -- [neu build flags]");
     process.exit(1);
 } else {
-    config.target = target;
-    logger.info("Configuration loaded.");
-    logger.info(`Target platform detected: ${target}`);
+    logger.info(`Target detected: ${target}`);
     if (neuBuildFlags.length > 0) {
         logger.info(`Forwarding core build flags: ${neuBuildFlags.join(' ')}`);
     }
-    builder.build(config).catch(() => {
+    builder.build(target, neuBuildFlags).catch(() => {
         process.exit(1);
     });
 }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,0 +1,24 @@
+const logger = require("../utils/logger");
+const precheck = require("./precheck");
+const stagingManager = require("./stagingmanager");
+const targetLoader = require("./targetloader");
+
+async function build(config) {
+    logger.info("Starting build pipeline...");
+
+    precheck(config);
+    logger.info("Environment pre-checks passed.");
+
+    const stagingPath = stagingManager.prepare(config);
+    logger.info("Staging folder prepared successfully.");
+
+    const target = targetLoader.load(config.target);
+    logger.info(`Target loaded: ${config.target}`);
+
+    await target.build(config, stagingPath);
+    logger.info("Packaging completed successfully!");
+
+    stagingManager.cleanup(stagingPath);
+}
+
+module.exports = { build };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,10 +1,17 @@
 const logger = require("../utils/logger");
+const resolveConfig = require("./configresolver");
 const precheck = require("./precheck");
 const stagingManager = require("./stagingmanager");
 const targetLoader = require("./targetloader");
 
-async function build(config) {
+async function build(target, neuBuildFlags) {
     logger.info("Starting build pipeline...");
+
+    const config = resolveConfig();
+    config.target = target;
+    config.neuBuildFlags = neuBuildFlags;
+
+    logger.info("Configuration loaded.");
 
     precheck(config);
     logger.info("Environment pre-checks passed.");
@@ -12,10 +19,10 @@ async function build(config) {
     const stagingPath = stagingManager.prepare(config);
     logger.info("Staging folder prepared successfully.");
 
-    const target = targetLoader.load(config.target);
+    const targetModule = targetLoader.load(config.target);
     logger.info(`Target loaded: ${config.target}`);
 
-    await target.build(config, stagingPath);
+    await targetModule.build(config, stagingPath);
     logger.info("Packaging completed successfully!");
 
     stagingManager.cleanup(stagingPath);

--- a/lib/stagingmanager.js
+++ b/lib/stagingmanager.js
@@ -16,13 +16,27 @@ function prepare(config) {
     const distDir = path.join(process.cwd(), "dist");
 
     if (!fs.existsSync(distDir)) {
-        logger.error("dist/ directory not found.");
+        logger.error("dist/ directory not found. Run neu build first.");
         throw new Error("dist/ directory not found.");
     }
 
-    fileUtils.copyDirectory(distDir, stagingDir);
-    logger.info(`Staging ready at: ${stagingDir}`);
+    if (config.buildType === "sea") {
+        logger.info("SEA build detected. Copying executable only...");
+        const files = fs.readdirSync(distDir);
+        files.forEach((file) => {
+            if (file !== "resources.neu") {
+                fileUtils.copyFile(
+                    path.join(distDir, file),
+                    path.join(stagingDir, file)
+                );
+            }
+        });
+    } else {
+        logger.info("Standard build detected. Copying all artifacts...");
+        fileUtils.copyDirectory(distDir, stagingDir);
+    }
 
+    logger.info(`Staging ready at: ${stagingDir}`);
     return stagingDir;
 }
 

--- a/lib/stagingmanager.js
+++ b/lib/stagingmanager.js
@@ -1,0 +1,37 @@
+const path = require("path");
+const fs = require("fs");
+const fileUtils = require("../utils/fileutils");
+const logger = require("../utils/logger");
+
+function prepare(config) {
+    const stagingDir = path.join(
+        process.cwd(),
+        ".neu-builder-staging"
+    );
+
+    logger.info("Preparing staging directory...");
+    fileUtils.removeDirectory(stagingDir);
+    fileUtils.ensureDirectory(stagingDir);
+
+    const distDir = path.join(process.cwd(), "dist");
+
+    if (!fs.existsSync(distDir)) {
+        logger.error("dist/ directory not found.");
+        throw new Error("dist/ directory not found.");
+    }
+
+    fileUtils.copyDirectory(distDir, stagingDir);
+    logger.info(`Staging ready at: ${stagingDir}`);
+
+    return stagingDir;
+}
+
+function cleanup(stagingDir) {
+    fileUtils.removeDirectory(stagingDir);
+    logger.info("Staging directory cleaned up.");
+}
+
+module.exports = {
+    prepare,
+    cleanup
+};

--- a/lib/targetloader.js
+++ b/lib/targetloader.js
@@ -1,0 +1,20 @@
+const path = require("path");
+const logger = require("../utils/logger");
+
+function load(targetName) {
+    try {
+        const targetPath = path.join(
+            __dirname,
+            "../targets",
+            targetName,
+            "index.js"
+        );
+        logger.info(`Loading target: ${targetName}`);
+        return require(targetPath);
+    } catch (err) {
+        logger.error(`Target '${targetName}' not found.`);
+        throw new Error(`Target '${targetName}' not found.`);
+    }
+}
+
+module.exports = { load };

--- a/spec/builder.spec.js
+++ b/spec/builder.spec.js
@@ -1,0 +1,40 @@
+const assert = require("assert");
+const path = require("path");
+const fs = require("fs");
+
+const stagingManager = require("../lib/stagingmanager");
+const targetLoader = require("../lib/targetloader");
+
+describe("Staging Manager", () => {
+    it("should throw error if dist directory not found", () => {
+        const config = {
+            target: "nsis",
+            arch: "x64"
+        };
+        assert.throws(() => {
+            stagingManager.prepare(config);
+        }, /dist\/ directory not found/);
+    });
+
+    it("should create staging directory", () => {
+        const distDir = path.join(process.cwd(), "dist");
+        fs.mkdirSync(distDir, { recursive: true });
+        fs.writeFileSync(path.join(distDir, "test.exe"), "dummy");
+
+        const config = { target: "nsis", arch: "x64" };
+        const stagingPath = stagingManager.prepare(config);
+
+        assert.ok(fs.existsSync(stagingPath));
+
+        stagingManager.cleanup(stagingPath);
+        fs.rmSync(distDir, { recursive: true, force: true });
+    });
+});
+
+describe("Target Loader", () => {
+    it("should throw error for invalid target", () => {
+        assert.throws(() => {
+            targetLoader.load("invalidtarget");
+        }, /not found/);
+    });
+});


### PR DESCRIPTION
****
Added:
- lib/builder.js: orchestrates the full build flow
  (precheck -> staging -> target loading -> packaging)
- lib/stagingmanager.js: creates a staging directory, 
  copies dist/ artifacts and cleans up after build
- lib/targetloader.js: dynamically loads the requested 
  target module from targets/ folder
- spec/builder.spec.js: basic tests for staging and target loader

Also updated index.js to wire everything together 
and call builder.build() with error handling.

****