### PR TITLE
chore: added additional configuration options in schema and restructure tests

### DIFF
--- a/constants/configschema.js
+++ b/constants/configschema.js
@@ -20,6 +20,7 @@ const resolvedConfig = {
     },
     metadata: {
         applicationId: null,
+        applicationName: null,
         version: null,
         maintainer: null,
         category: null,

--- a/constants/configschema.js
+++ b/constants/configschema.js
@@ -5,16 +5,29 @@ const cliOptions = {
 };
 
 const resolvedConfig = {
-
     hostPlatform: null,
     targetPlatform: null,
     target: null,
     arch: "x64",
     buildType: "standard",
-    assets: {},
-    metadata: {},
-    paths: {}
-
+    assets: {
+        icon: null,
+        desktopEntry: null,
+        license: null,
+        sidebarImage: null,
+        headerImage: null,
+        background: null
+    },
+    metadata: {
+        applicationId: null,
+        version: null,
+        maintainer: null,
+        category: null,
+        description: null
+    },
+    paths: {
+        output: null
+    }
 };
 
 module.exports = {

--- a/constants/configschema.js
+++ b/constants/configschema.js
@@ -12,7 +12,6 @@ const resolvedConfig = {
     buildType: "standard",
     assets: {
         icon: null,
-        desktopEntry: null,
         license: null,
         sidebarImage: null,
         headerImage: null,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const config = resolveConfig();
 config.neuBuildFlags = neuBuildFlags;
 
 logger.info("Configuration loaded.");
-
+logger.info(config);
 if (!target) {
     logger.warn("No target specified. Usage: neu-builder <target> -- [neu build flags]");
 } else {

--- a/lib/configresolver.js
+++ b/lib/configresolver.js
@@ -87,7 +87,22 @@ function resolveConfig(
     finalConfig.assets = {
 
         icon:
-            targetConfig.icon || null
+            targetConfig.icon || null,
+
+        desktopEntry:
+            targetConfig.desktopEntry || null,
+
+        license:
+            targetConfig.license || null,
+
+        sidebarImage:
+            targetConfig.sidebarImage || null,
+
+        headerImage:
+            targetConfig.headerImage || null,
+
+        background:
+            targetConfig.background || null,
 
     };
     finalConfig.metadata = {
@@ -96,10 +111,18 @@ function resolveConfig(
             config.applicationId || null,
 
         version:
-            config.version || null
+            config.version || null,
+
+        maintainer:
+            targetConfig.maintainer || null,
+
+        category:
+            targetConfig.category || null,
+
+        description:
+            targetConfig.description || null,
 
     };
-
     finalConfig.paths = {
         output:
             targetConfig.output

--- a/lib/configresolver.js
+++ b/lib/configresolver.js
@@ -89,9 +89,6 @@ function resolveConfig(
         icon:
             targetConfig.icon || null,
 
-        desktopEntry:
-            targetConfig.desktopEntry || null,
-
         license:
             targetConfig.license || null,
 
@@ -111,18 +108,18 @@ function resolveConfig(
             config.applicationId || null,
 
         applicationName:
-            config.applicationName || null,
+            config.applicationName || "Neutralino Application",
         version:
-            config.version || null,
+            config.version || "1.0.0",
 
         maintainer:
-            targetConfig.maintainer || null,
+            targetConfig.maintainer || "Unknown",
 
         category:
-            targetConfig.category || null,
+            targetConfig.category || "Utility",
 
         description:
-            targetConfig.description || null,
+            targetConfig.description || "Neutralino Application",
 
     };
     finalConfig.paths = {

--- a/lib/configresolver.js
+++ b/lib/configresolver.js
@@ -110,6 +110,8 @@ function resolveConfig(
         applicationId:
             config.applicationId || null,
 
+        applicationName:
+            config.applicationName || null,
         version:
             config.version || null,
 

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -1,5 +1,6 @@
 {
   "applicationId": "com.example.myapp",
+  "applicationName": "My First Builder App",
   "version": "1.0.0",
   "defaultMode": "window",
 
@@ -17,7 +18,7 @@
             "sidebarImage": "/installerassets/windows/nsis/sidebar.bmp",
             "headerImage": "/installerassets/windows/nsis/header.bmp",
             "license": "/installerassets/LICENSE.txt",
-            "output": "/dist/windows"
+            "output": "./dist/windows"
           }
         ]
       },
@@ -33,7 +34,7 @@
             "icon": "/installerassets/linux/deb/app.png",
             "desktopEntry": "/installerassets/linux/deb/myapp.desktop",
             "category": "Utility",
-            "output": "/dist/linux",
+            "output": "./dist/linux",
             "maintainer": "GSoC"
           },
           {
@@ -45,7 +46,7 @@
             "icon": "/installerassets/linux/appimage/app.png",
             "desktopEntry": "/installerassets/linux/appimage/myapp.desktop",
             "license": "/installerassets/LICENSE.txt",
-            "output": "/dist/linux",
+            "output": "./dist/linux",
             "maintainer": "GSoC"
           }
         ]
@@ -61,7 +62,7 @@
             ],
             "icon": "/installerassets/mac/dmg/app.icns",
             "background": "/installerassets/mac/dmg/dmg-background.png",
-            "output": "/dist/mac"
+            "output": "./dist/mac"
           }
         ]
       }

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -14,10 +14,10 @@
               "x64",
               "ia32"
             ],
-            "icon": "/installerassets/windows/nsis/app.ico",
-            "sidebarImage": "/installerassets/windows/nsis/sidebar.bmp",
-            "headerImage": "/installerassets/windows/nsis/header.bmp",
-            "license": "/installerassets/LICENSE.txt",
+            "icon": "./installerassets/windows/nsis/app.ico",
+            "sidebarImage": "./installerassets/windows/nsis/sidebar.bmp",
+            "headerImage": "./installerassets/windows/nsis/header.bmp",
+            "license": "./installerassets/LICENSE.txt",
             "output": "./dist/windows"
           }
         ]
@@ -31,8 +31,7 @@
               "ia32",
               "armhf"
             ],
-            "icon": "/installerassets/linux/deb/app.png",
-            "desktopEntry": "/installerassets/linux/deb/myapp.desktop",
+            "icon": "./installerassets/linux/deb/app.png",
             "category": "Utility",
             "output": "./dist/linux",
             "maintainer": "GSoC"
@@ -43,9 +42,8 @@
               "x64",
               "arm64"
             ],
-            "icon": "/installerassets/linux/appimage/app.png",
-            "desktopEntry": "/installerassets/linux/appimage/myapp.desktop",
-            "license": "/installerassets/LICENSE.txt",
+            "icon": "./installerassets/linux/appimage/app.png",
+            "license": "./installerassets/LICENSE.txt",
             "output": "./dist/linux",
             "maintainer": "GSoC"
           }
@@ -60,8 +58,8 @@
               "arm64",
               "universal"
             ],
-            "icon": "/installerassets/mac/dmg/app.icns",
-            "background": "/installerassets/mac/dmg/dmg-background.png",
+            "icon": "./installerassets/mac/dmg/app.icns",
+            "background": "./installerassets/mac/dmg/dmg-background.png",
             "output": "./dist/mac"
           }
         ]

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -33,7 +33,8 @@
             "icon": "/installerassets/linux/deb/app.png",
             "desktopEntry": "/installerassets/linux/deb/myapp.desktop",
             "category": "Utility",
-            "output": "/dist/linux"
+            "output": "/dist/linux",
+            "maintainer": "GSoC"
           },
           {
             "target": "appimage",
@@ -44,7 +45,8 @@
             "icon": "/installerassets/linux/appimage/app.png",
             "desktopEntry": "/installerassets/linux/appimage/myapp.desktop",
             "license": "/installerassets/LICENSE.txt",
-            "output": "/dist/linux"
+            "output": "/dist/linux",
+            "maintainer": "GSoC"
           }
         ]
       },

--- a/spec/configresolver.spec.js
+++ b/spec/configresolver.spec.js
@@ -35,180 +35,105 @@ function validateTarget(
 describe(
     "Config Resolver",
     () => {
-
         it(
             "should detect host and target platforms separately",
             () => {
-
                 const config =
                     resolveConfig([
                         "nsis",
                         "--x64"
                     ]);
-
                 assert.equal(
                     config.targetPlatform,
                     "windows"
                 );
-
                 assert.ok(
                     config.hostPlatform
                 );
-
             }
         );
-
         describe(
             "NSIS",
             () => {
-
                 it(
                     "should resolve x64",
                     () => {
 
-                        validateTarget(
-                            "nsis",
-                            "x64",
-                            "windows"
-                        );
-
+                        validateTarget("nsis", "x64", "windows");
                     }
                 );
-
                 it(
                     "should resolve ia32",
                     () => {
-
-                        validateTarget(
-                            "nsis",
-                            "ia32",
-                            "windows"
-                        );
-
+                        validateTarget("nsis", "ia32", "windows");
                     }
                 );
-
             }
         );
-
         describe(
             "DEB",
             () => {
-
                 it(
                     "should resolve x64",
                     () => {
-
-                        validateTarget(
-                            "deb",
-                            "x64",
-                            "linux"
-                        );
-
+                        validateTarget("deb", "x64", "linux");
                     }
                 );
-
                 it(
                     "should resolve ia32",
                     () => {
-
-                        validateTarget(
-                            "deb",
-                            "ia32",
-                            "linux"
-                        );
-
+                        validateTarget("deb", "ia32", "linux");
                     }
                 );
-
                 it(
                     "should resolve armhf",
                     () => {
-
-                        validateTarget(
-                            "deb",
-                            "armhf",
-                            "linux"
-                        );
+                        validateTarget("deb", "armhf", "linux");
 
                     }
                 );
-
             }
         );
-
         describe(
             "AppImage",
             () => {
-
                 it(
                     "should resolve x64",
                     () => {
-
-                        validateTarget(
-                            "appimage",
-                            "x64",
-                            "linux"
-                        );
+                        validateTarget("appimage", "x64", "linux");
 
                     }
                 );
-
                 it(
                     "should resolve arm64",
                     () => {
-
-                        validateTarget(
-                            "appimage",
-                            "arm64",
-                            "linux"
-                        );
-
+                        validateTarget("appimage", "arm64", "linux");
                     }
                 );
-
             }
         );
-
         describe(
             "DMG",
             () => {
-
                 it(
                     "should resolve x64",
                     () => {
 
-                        validateTarget(
-                            "dmg",
-                            "x64",
-                            "mac"
-                        );
+                        validateTarget("dmg", "x64", "mac");
 
                     }
                 );
-
                 it(
                     "should resolve arm64",
                     () => {
 
-                        validateTarget(
-                            "dmg",
-                            "arm64",
-                            "mac"
-                        );
-
+                        validateTarget("dmg", "arm64", "mac");
                     }
                 );
-
                 it(
                     "should resolve universal",
                     () => {
-
-                        validateTarget(
-                            "dmg",
-                            "universal",
-                            "mac"
-                        );
+                        validateTarget("dmg", "universal", "mac");
 
                     }
                 );

--- a/spec/configresolver.spec.js
+++ b/spec/configresolver.spec.js
@@ -1,10 +1,41 @@
 const assert = require("assert");
+
 const resolveConfig =
     require("../lib/configresolver");
+
+function validateTarget(
+    target,
+    arch,
+    platform
+) {
+
+    const config =
+        resolveConfig([
+            target,
+            `--${arch}`
+        ]);
+
+    assert.equal(
+        config.target,
+        target
+    );
+
+    assert.equal(
+        config.arch,
+        arch
+    );
+
+    assert.equal(
+        config.targetPlatform,
+        platform
+    );
+
+}
 
 describe(
     "Config Resolver",
     () => {
+
         it(
             "should detect host and target platforms separately",
             () => {
@@ -14,94 +45,172 @@ describe(
                         "nsis",
                         "--x64"
                     ]);
+
                 assert.equal(
                     config.targetPlatform,
                     "windows"
                 );
+
                 assert.ok(
                     config.hostPlatform
                 );
-            }
-        );
-        it(
-            "should resolve nsis target arch x64",
-            () => {
-
-                const config =
-                    resolveConfig([
-                        "nsis",
-                        "--x64"
-                    ]);
-
-                assert.equal(
-                    config.target,
-                    "nsis"
-                );
-
-                assert.equal(
-                    config.arch,
-                    "x64"
-                );
-
-                assert.equal(
-                    config.targetPlatform,
-                    "windows"
-                );
 
             }
         );
 
-        it(
-            "should resolve appimage target arch x64",
+        describe(
+            "NSIS",
             () => {
 
-                const config =
-                    resolveConfig([
-                        "appimage",
-                        "--x64"
-                    ]);
+                it(
+                    "should resolve x64",
+                    () => {
 
-                assert.equal(
-                    config.target,
-                    "appimage"
+                        validateTarget(
+                            "nsis",
+                            "x64",
+                            "windows"
+                        );
+
+                    }
                 );
 
-                assert.equal(
-                    config.arch,
-                    "x64"
-                );
+                it(
+                    "should resolve ia32",
+                    () => {
 
-                assert.equal(
-                    config.targetPlatform,
-                    "linux"
+                        validateTarget(
+                            "nsis",
+                            "ia32",
+                            "windows"
+                        );
+
+                    }
                 );
 
             }
         );
 
-        it(
-            "should resolve dmg target arch x64",
+        describe(
+            "DEB",
             () => {
 
-                const config =
-                    resolveConfig([
-                        "dmg",
-                        "--x64"
-                    ]);
+                it(
+                    "should resolve x64",
+                    () => {
 
-                assert.equal(
-                    config.target,
-                    "dmg"
+                        validateTarget(
+                            "deb",
+                            "x64",
+                            "linux"
+                        );
+
+                    }
                 );
 
-                assert.equal(
-                    config.arch,
-                    "x64"
+                it(
+                    "should resolve ia32",
+                    () => {
+
+                        validateTarget(
+                            "deb",
+                            "ia32",
+                            "linux"
+                        );
+
+                    }
                 );
 
-                assert.equal(
-                    config.targetPlatform,
-                    "mac"
+                it(
+                    "should resolve armhf",
+                    () => {
+
+                        validateTarget(
+                            "deb",
+                            "armhf",
+                            "linux"
+                        );
+
+                    }
+                );
+
+            }
+        );
+
+        describe(
+            "AppImage",
+            () => {
+
+                it(
+                    "should resolve x64",
+                    () => {
+
+                        validateTarget(
+                            "appimage",
+                            "x64",
+                            "linux"
+                        );
+
+                    }
+                );
+
+                it(
+                    "should resolve arm64",
+                    () => {
+
+                        validateTarget(
+                            "appimage",
+                            "arm64",
+                            "linux"
+                        );
+
+                    }
+                );
+
+            }
+        );
+
+        describe(
+            "DMG",
+            () => {
+
+                it(
+                    "should resolve x64",
+                    () => {
+
+                        validateTarget(
+                            "dmg",
+                            "x64",
+                            "mac"
+                        );
+
+                    }
+                );
+
+                it(
+                    "should resolve arm64",
+                    () => {
+
+                        validateTarget(
+                            "dmg",
+                            "arm64",
+                            "mac"
+                        );
+
+                    }
+                );
+
+                it(
+                    "should resolve universal",
+                    () => {
+
+                        validateTarget(
+                            "dmg",
+                            "universal",
+                            "mac"
+                        );
+
+                    }
                 );
 
             }


### PR DESCRIPTION
This PR adds support for developers to mention additional options and assets for packaging their app. Such as mentioning license, maintainer name and etc.

These fields are optional and if not specified they can be left blank during the packaging for that target.

This PR also refactors the structure of the existing tests related to the ``configresolver`` so the tests are grouped in a better way and also adds all the tests related to the config resolution.