### PR TITLE
feat: integrate plugin with neu CLI command system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # neutralinojs-builder
 
-``neutralinojs-builder`` is a lightweight neu CLI plugin for generating platform-specific installers and distributable packages for Neutralinojs applications.
+`neutralinojs-builder` is a lightweight neu CLI plugin for generating platform-specific installers and distributable packages for Neutralinojs applications.
 
 It sits on top of the existing neu build workflow and automates packaging for different platforms using the appropriate native tools. The goal is to keep the Neutralinojs CLI minimal while still making app distribution easy and consistent.
 
@@ -31,7 +31,6 @@ It sits on top of the existing neu build workflow and automates packaging for di
 
 ## Installation
 
-
 ```bash
 # Installing the plugin
 neu plugins --add @neutralinojs-community/builder
@@ -49,5 +48,22 @@ neu builder
 neu plugins --remove @neutralinojs-community/builder
 ```
 
+---
+
+## Progress
+
+- [x] Task 1: Plugin core initializer (SEA support)
+- [x] Task 2: Configuration & dependency pre-check
+- [ ] Task 3: Windows NSIS installer
+- [ ] Task 4: Linux DEB package
+- [ ] Task 5: Linux AppImage
+- [ ] Task 6: macOS DMG installer
+- [x] Task 7: CLI integration
+- [ ] Task 8: Testing & CI/CD pipeline
+- [ ] Task 9: Documentation & refinement
+
+---
+
 ## Development Status
+
 This project is currently under active development and the initial release is expected soon. The architecture and implementation may evolve during development as the packaging pipeline and platform targets change.

--- a/index.js
+++ b/index.js
@@ -1,27 +1,54 @@
-#!/usr/bin/env node
-
 const logger = require("./utils/logger");
 const builder = require("./lib/builder");
 
-const args = process.argv.slice(2);
-const separatorIndex = args.indexOf('--');
-const passedFlags = separatorIndex !== -1 ? args.slice(0, separatorIndex) : args;
-const neuBuildFlags = separatorIndex !== -1 ? args.slice(separatorIndex + 1) : [];
-const target = passedFlags.find(arg => !arg.startsWith('-'));
+module.exports = {
+    command: "builder",
+    register: (cmd) => {
+        cmd
+            .description("builds installer packages for Neutralinojs apps")
+            .arguments("<target>")
+            .allowUnknownOption(true)
+            .action(async (target, options, command) => {
+                const rawArgs = command.parent.rawArgs;
+                const separatorIndex = rawArgs.indexOf("--");
+                const neuBuildFlags = separatorIndex !== -1
+                    ? rawArgs.slice(separatorIndex + 1)
+                    : [];
 
-logger.info("Configuration loaded.");
-logger.info(config);
-logger.info("Neutralinojs Builder initialized.");
+                logger.info("Neutralinojs Builder initialized.");
+                logger.info(`Target detected: ${target}`);
+                if (neuBuildFlags.length > 0) {
+                    logger.info(`Forwarding core build flags: ${neuBuildFlags.join(' ')}`);
+                }
 
-if (!target) {
-    logger.warn("No target specified. Usage: neu-builder <target> -- [neu build flags]");
-    process.exit(1);
-} else {
-    logger.info(`Target detected: ${target}`);
-    if (neuBuildFlags.length > 0) {
-        logger.info(`Forwarding core build flags: ${neuBuildFlags.join(' ')}`);
+                try {
+                    await builder.build(target, neuBuildFlags);
+                } catch (err) {
+                    process.exit(1);
+                }
+            });
     }
-    builder.build(target, neuBuildFlags).catch(() => {
+};
+
+if (require.main === module) {
+    const args = process.argv.slice(2);
+    const separatorIndex = args.indexOf('--');
+    const passedFlags = separatorIndex !== -1 ? args.slice(0, separatorIndex) : args;
+    const neuBuildFlags = separatorIndex !== -1 ? args.slice(separatorIndex + 1) : [];
+    const target = passedFlags.find(arg => !arg.startsWith('-'));
+
+    logger.info("Neutralinojs Builder initialized standalone.");
+
+    if (!target) {
+        logger.warn("No target specified. Usage: node index.js <target> -- [neu build flags]");
         process.exit(1);
-    });
+    } else {
+        logger.info(`Target detected: ${target}`);
+        if (neuBuildFlags.length > 0) {
+            logger.info(`Forwarding core build flags: ${neuBuildFlags.join(' ')}`);
+        }
+        builder.build(target, neuBuildFlags).catch(() => {
+            process.exit(1);
+        });
+    }
 }

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -7,7 +7,7 @@ const targetLoader = require("./targetloader");
 async function build(target, neuBuildFlags) {
     logger.info("Starting build pipeline...");
 
-    const config = resolveConfig();
+    const config = resolveConfig([]);
     config.target = target;
     config.neuBuildFlags = neuBuildFlags;
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "A standalone Neutralinojs CLI plugin for packaging and installer generation",
   "main": "index.js",
-  "bin": {
-    "neu-builder": "./index.js"
-  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/spec/integration.spec.js
+++ b/spec/integration.spec.js
@@ -1,0 +1,40 @@
+const assert = require("assert");
+
+describe("CLI Plugin Integration", () => {
+    const plugin = require("../index.js");
+
+    it("should export correct command name", () => {
+        assert.strictEqual(plugin.command, "builder");
+    });
+
+    it("should export a register function", () => {
+        assert.strictEqual(typeof plugin.register, "function");
+    });
+
+    it("should register builder command with description and action", () => {
+        let registeredDescription = null;
+        let actionCallback = null;
+
+        const fakeCmd = {
+            description(desc) {
+                registeredDescription = desc;
+                return this;
+            },
+            arguments() {
+                return this;
+            },
+            allowUnknownOption() {
+                return this;
+            },
+            action(cb) {
+                actionCallback = cb;
+                return this;
+            }
+        };
+
+        plugin.register(fakeCmd);
+
+        assert.ok(registeredDescription.includes("installer"));
+        assert.strictEqual(typeof actionCallback, "function");
+    });
+});


### PR DESCRIPTION
Completes Task 7 (CLI Integration).

Changes:
- index.js now exports {command, register} matching neu CLI's
  pluginloader.js contract
- Fixed commander.js compatibility: neu CLI ships with commander
  v7.2.0 which only supports .arguments(), not .argument()
- Fixed builder.js passing resolveConfig() with no args, which
  caused arch to incorrectly pick up the target name. Now uses
  resolveConfig([]) since target/arch parsing happens in index.js
- Added spec/integration.spec.js to validate the plugin contract
- Removed unused "bin" field from package.json
- Added progress checklist to README.md

Testing done:
- Ran full local test suite (spec/) - 17/17 passing
- Verified manually end-to-end with real neu CLI:
  npm link → cd into neu CLI's own node_modules and 
  npm install the plugin → registered it in neu's plugin 
  config → ran "neu builder nsis" successfully through 
  the actual neu command, confirmed full pipeline runs 
  (config resolve → precheck → staging → target loader)
- Pipeline correctly stops with a clear error when makensis 
  is not installed on the host, confirming precheck validation 
  works as expected through the real CLI path