### PR TITLE
feat: Implemented debian packaging using deboa

### DIFF
--- a/targets/deb/debvalidator.js
+++ b/targets/deb/debvalidator.js
@@ -1,0 +1,113 @@
+const fs = require("fs");
+const path = require("path");
+const logger = require("../../utils/logger");
+
+function resolveAssetPath(assetPath) {
+    if (!assetPath) {
+        return null;
+    }
+
+    const normalizedPath = assetPath.trim();
+
+    const candidates = [];
+
+    if (path.isAbsolute(normalizedPath)) {
+        candidates.push(normalizedPath);
+
+        candidates.push(
+            path.resolve(
+                process.cwd(),
+                normalizedPath.replace(/^\/+/, "")
+            )
+        );
+    } else {
+        candidates.push(
+            path.resolve(
+                process.cwd(),
+                normalizedPath
+            )
+        );
+    }
+
+    return candidates.find(fs.existsSync) || candidates[0];
+}
+
+function validateMetadata(config) {
+
+    if (!config.metadata) {
+        throw new Error("DebValidator: Missing metadata configuration.");
+    }
+
+    if (!config.metadata.applicationId) {
+        throw new Error("DebValidator: metadata.applicationId is required.");
+    }
+}
+function validateAssets(config) {
+
+    const assets = config.assets || {};
+
+    const requiredAssets = [
+        // future required assets
+    ];
+
+    const optionalAssets = [
+        "icon",
+        "license"
+    ];
+
+    for (const assetName of requiredAssets) {
+
+        const assetPath =
+            assets[assetName];
+
+        if (!assetPath) {
+            throw new Error(`DebValidator: Required asset '${assetName}' is missing.`);
+        }
+
+        const resolvedPath =
+            resolveAssetPath(assetPath);
+
+        if (!fs.existsSync(resolvedPath)) {
+            throw new Error(`DebValidator: Required asset '${assetName}' not found: ${resolvedPath}`);
+        }
+        logger.info(`DebValidator: Required asset '${assetName}' found: ${resolvedPath}.`);
+
+        assets[assetName] = resolvedPath;
+    }
+
+    for (const assetName of optionalAssets) {
+
+        const assetPath = assets[assetName];
+
+        if (!assetPath) {
+            continue;
+        }
+
+        const resolvedPath = resolveAssetPath(assetPath);
+
+        if (!fs.existsSync(resolvedPath)) {
+            logger.warn(`DebValidator: Optional asset '${assetName}' not found: ${resolvedPath}. Skipping.`);
+
+            assets[assetName] = null;
+            continue;
+        }
+        logger.info(`DebValidator: Optional asset '${assetName}' found: ${resolvedPath}.`);
+
+        assets[assetName] = resolvedPath;
+    }
+
+    config.assets = assets;
+}
+
+function validateDeb(config) {
+
+    logger.info("DVAL: Validating DEB configuration...");
+    validateMetadata(config);
+    validateAssets(config);
+    logger.info("DebValidator: DEB configuration validated.");
+    return config;
+}
+
+module.exports = {
+    validateDeb
+};

--- a/targets/deb/index.js
+++ b/targets/deb/index.js
@@ -1,0 +1,33 @@
+const logger = require("../../utils/logger");
+
+const buildPackage = require("./packagebuilder");
+
+const {
+    prepareDebLayout,
+    validateDebLayout,
+} = require("./staginglayout");
+
+const {
+    validateDeb
+} = require("./debvalidator");
+
+async function build(config, stagingPath) {
+    let packagePath;
+    try {
+        logger.info("DEB: Starting DEB packaging...");
+        validateDeb(config);
+        prepareDebLayout(config, stagingPath);
+        validateDebLayout(config, stagingPath);
+        packagePath = await buildPackage(config, stagingPath);
+        logger.info(`DEB: Generated package: ${packagePath}`);
+    } catch (error) {
+        console.error(error);
+        throw error
+    }
+
+    return packagePath;
+}
+
+module.exports = {
+    build,
+};

--- a/targets/deb/packagebuilder.js
+++ b/targets/deb/packagebuilder.js
@@ -1,0 +1,131 @@
+const fs = require("fs");
+const path = require("path");
+
+const deboaProvider =
+    require("./providers/deboa");
+
+function sanitizePackageName(name) {
+    return String(name || "neutralino-app")
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9.+-]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^[.-]+|[.-]+$/g, "") || "neutralino-app";
+}
+
+async function buildPackage(config, stagingPath) {
+
+    const metadata =
+        config.metadata || {};
+
+    const packageName =
+        sanitizePackageName(
+            metadata.applicationId
+        );
+
+    const outputDir = path.resolve(
+        process.cwd(),
+        config.paths?.output ||
+        "./dist/linux"
+    );
+
+    fs.mkdirSync(
+        outputDir,
+        { recursive: true }
+    );
+
+    for (const file of fs.readdirSync(outputDir)) {
+        if (file.endsWith(".deb")) {
+            fs.rmSync(
+                path.join(
+                    outputDir,
+                    file
+                ),
+                { force: true }
+            );
+        }
+    }
+
+    const executableName =
+        metadata.resolvedBinaryName;
+
+    if (!executableName) {
+        throw new Error(
+            "PackageBuilder: Missing metadata.resolvedBinaryName"
+        );
+    }
+
+    const outputFile =
+        await deboaProvider.createPackage({
+            sourceDir: stagingPath,
+            targetDir: outputDir,
+            installationRoot: `/opt/${packageName}`,
+            icon: config.assets?.icon || undefined,
+            controlFileOptions: {
+                packageName,
+                version: metadata.version || "1.0.0",
+                maintainer: metadata.maintainer || "Unknown",
+                shortDescription: metadata.description || "Neutralino Application",
+            },
+            beforeCreateDesktopEntry:
+                (entry) => {
+                    entry.Name = metadata.applicationName || packageName;
+                    entry.GenericName = metadata.applicationName || packageName;
+                    entry.Comment = metadata.description || "";
+                    entry.Exec = `/bin/sh -c "cd /opt/${packageName} && ./${executableName}"`;
+                    entry.Icon = packageName;
+                    entry.Categories = metadata.category || "Utility";
+                    entry.Terminal = false;
+                    return entry;
+                },
+
+            // TODO: ADD SYMLINK LATER. Handle it later or remove this. But keeping this for reference.
+            // additionalTarEntries: [
+            //     {
+            //         gname: "root",
+            //         uname: "root",
+            //         type: "symlink",
+            //         mode: parseInt(
+            //             "777",
+            //             8
+            //         ),
+            //         linkname: `../../opt/${packageName}/${executableName}`,
+            //         name:`usr/bin/${executableName}`
+            //     }
+            // ],
+
+            modifyTarHeader:
+                (header) => {
+
+                    if (
+                        path.basename(
+                            header.name
+                        ) === executableName
+                    ) {
+                        header.mode =
+                            parseInt(
+                                "0755",
+                                8
+                            );
+                    }
+
+                    return header;
+                }
+        });
+
+    const stats = fs.statSync(outputFile);
+
+    // TODO: Handle it later or remove this. But keeping this for reference.
+    // Temp fix/workaround for Deboa odd-size archive issue
+    // if (stats.size % 2 !== 0) {
+    //     fs.appendFileSync(
+    //         outputFile,
+    //         "\n"
+    //     );
+    // }
+
+    return outputFile;
+}
+
+module.exports =
+    buildPackage;

--- a/targets/deb/providers/deboa.js
+++ b/targets/deb/providers/deboa.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const path = require("path");
+const { Deboa } = require("deboa");
+
+async function createPackage(options) {
+
+    const deboa = new Deboa({
+        sourceDir: options.sourceDir,
+        targetDir: options.targetDir,
+        installationRoot: options.installationRoot,
+        icon: options.icon,
+        controlFileOptions: options.controlFileOptions,
+        beforeCreateDesktopEntry: options.beforeCreateDesktopEntry,
+        modifyTarHeader: options.modifyTarHeader
+    });
+
+    await deboa.package();
+
+    const generated =
+        fs.readdirSync(options.targetDir)
+            .find(file =>
+                file.endsWith(".deb")
+            );
+
+    if (!generated) {
+        throw new Error(
+            "DeboaProvider: Failed to generate package."
+        );
+    }
+
+    return path.join(
+        options.targetDir,
+        generated
+    );
+}
+
+module.exports = {
+    createPackage
+};

--- a/targets/deb/staginglayout.js
+++ b/targets/deb/staginglayout.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+
+function prepareDebLayout(config, stagingPath) {
+    const metadata = config.metadata || {};
+
+    const files = fs.readdirSync(stagingPath);
+
+    const binaryFile = files.find((file) => {
+        if (file === "resources.neu") {
+            return false;
+        }
+
+        const fullPath = path.join(stagingPath, file);
+        return fs.statSync(fullPath).isFile();
+    });
+
+    if (!binaryFile) {
+        throw new Error("StagingLayout: Unable to locate Neutralino binary.");
+    }
+
+    // Keep original filename
+    metadata.resolvedBinaryName = binaryFile;
+    config.metadata = metadata;
+
+    return binaryFile;
+}
+
+function validateDebLayout(config, stagingPath) {
+    if (!fs.existsSync(stagingPath)) {
+        throw new Error("StagingLayout: Invalid staging directory");
+    }
+
+    const files = fs.readdirSync(stagingPath);
+
+    const hasBinary = files.some((file) => {
+        if (file === "resources.neu") {
+            return false;
+        }
+
+        return fs.statSync(
+            path.join(stagingPath, file)
+        ).isFile();
+    });
+
+    if (!hasBinary) {
+        throw new Error("StagingLayout: Missing application binary.");
+    }
+
+    if (
+        config.buildType !== "sea" &&
+        !files.includes("resources.neu")
+    ) {
+        throw new Error(
+            "StagingLayout: Missing resources.neu."
+        );
+    }
+}
+
+module.exports = {
+    prepareDebLayout,
+    validateDebLayout
+};


### PR DESCRIPTION

This PR adds support for Debian package generation using Deboa. The implementation introduces a complete DEB packaging workflow that takes the staged Neutralino application and produces an installable `.deb` package with desktop integration support in ``dist/[target]`` or ``dist/linux`` directory.

The packaging pipeline includes validation of DEB-specific configuration, metadata, and assets before packaging begins. It also validates the staging layout to ensure that the required application files are present and correctly structured prior to package creation.

To keep the implementation maintainable and extensible, Deboa has been integrated through a provider abstraction layer rather than being used directly throughout the packaging logic. This makes it easier to replace the underlying packaging implementation in the future without affecting the rest of the DEB packaging workflow.

The generated packages include desktop integration support through automatic desktop entry generation and application icon installation. The implementation has been tested by generating packages, validating their contents, installing them through `dpkg`, and verifying successful application execution on Ubuntu.

This PR depends on #12  and should be merged after it.

## TODOs.
A few tasks which must be done in this PR or in another PR after getting the approval on implementation.
1. In ``packagebuilder.js`` address the commented out TODOs and potential issues.
2. Add tests related to deb packaging in this PR or in next PR.