### PR TITLE
feat: implement NSIS installer packaging

### DIFF
--- a/lib/stagingmanager.js
+++ b/lib/stagingmanager.js
@@ -4,9 +4,9 @@ const fileUtils = require("../utils/fileutils");
 const logger = require("../utils/logger");
 
 const PLATFORM_SUFFIXES = {
-    windows: [".exe"],
-    linux: ["_linux_x64", "_linux_armhf", "_linux_arm64"],
-    mac: ["_mac_x64", "_mac_arm64", "_mac_universal"]
+    windows: ["-win_x64.exe"],
+    linux: ["-linux_x64", "-linux_armhf", "-linux_arm64"],
+    mac: ["-mac_x64", "-mac_arm64", "-mac_universal"]
 };
 
 function findAppDistDir(distDir) {

--- a/lib/stagingmanager.js
+++ b/lib/stagingmanager.js
@@ -73,6 +73,7 @@ function prepare(config) {
     }
 
     const binaryFile = binaries[0];
+    config.metadata.resolvedBinaryName = binaryFile;
 
     fileUtils.copyFile(
         path.join(appDistDir, binaryFile),

--- a/lib/stagingmanager.js
+++ b/lib/stagingmanager.js
@@ -3,6 +3,35 @@ const fs = require("fs");
 const fileUtils = require("../utils/fileutils");
 const logger = require("../utils/logger");
 
+const PLATFORM_SUFFIXES = {
+    windows: [".exe"],
+    linux: ["_linux_x64", "_linux_armhf", "_linux_arm64"],
+    mac: ["_mac_x64", "_mac_arm64", "_mac_universal"]
+};
+
+function findAppDistDir(distDir) {
+    const entries = fs.readdirSync(distDir, { withFileTypes: true });
+    const appDirs = entries.filter((entry) => {
+        if (!entry.isDirectory()) {
+            return false;
+        }
+        const candidatePath = path.join(distDir, entry.name);
+        return fs.existsSync(path.join(candidatePath, "resources.neu"));
+    });
+
+    if (appDirs.length === 0) {
+        throw new Error("No application output folder found in dist/. Run neu build first.");
+    }
+
+    if (appDirs.length > 1) {
+        throw new Error(
+            `Multiple application folders found in dist/: ${appDirs.map((d) => d.name).join(", ")}. Unable to determine which one to package.`
+        );
+    }
+
+    return path.join(distDir, appDirs[0].name);
+}
+
 function prepare(config) {
     const stagingDir = path.join(
         process.cwd(),
@@ -20,29 +49,38 @@ function prepare(config) {
         throw new Error("dist/ directory not found.");
     }
 
-    const files = fs.readdirSync(distDir);
-    const binaries = files.filter((file) => {
-        const fullPath = path.join(distDir, file);
+    const appDistDir = findAppDistDir(distDir);
+
+    const files = fs.readdirSync(appDistDir);
+    const candidateFiles = files.filter((file) => {
+        const fullPath = path.join(appDistDir, file);
         return (fs.statSync(fullPath).isFile() && file !== "resources.neu");
     });
 
+    const suffixes = PLATFORM_SUFFIXES[config.targetPlatform] || [];
+    const binaries = candidateFiles.filter((file) =>
+        suffixes.some((suffix) => file.includes(suffix))
+    );
+
     if (binaries.length === 0) {
-        throw new Error("Unable to locate Neutralino binary in dist/");
+        throw new Error(
+            `Unable to locate Neutralino binary for platform '${config.targetPlatform}' in dist/. Found: ${candidateFiles.join(", ") || "none"}`
+        );
     }
 
     if (binaries.length > 1) {
-        throw new Error(`Multiple binaries found in dist/: ${binaries.join(", ")}`);
+        throw new Error(`Multiple binaries matched platform '${config.targetPlatform}': ${binaries.join(", ")}`);
     }
 
     const binaryFile = binaries[0];
 
     fileUtils.copyFile(
-        path.join(distDir, binaryFile),
+        path.join(appDistDir, binaryFile),
         path.join(stagingDir, binaryFile)
     );
 
     if (config.buildType !== "sea") {
-        const resourcesFile = path.join(distDir, "resources.neu");
+        const resourcesFile = path.join(appDistDir, "resources.neu");
         if (!fs.existsSync(resourcesFile)) {
             throw new Error("resources.neu not found in dist/");
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
-        "deboa": "^1.2.0"
-      },
-      "bin": {
-        "neu-builder": "index.js"
+        "deboa": "^1.2.0",
+        "makensis": "^3.0.5"
       }
+    },
+    "node_modules/@nsis/language-data": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@nsis/language-data/-/language-data-0.11.0.tgz",
+      "integrity": "sha512-zDjwKTzVEiGcQLhpxeg9KJ7BnWS3VOf5KN921KD0dMa8/q/7hDAES8cuwOxnwAvmQakdIwRGeLpJNJKFLkjmuA==",
+      "license": "Zlib"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -813,6 +817,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/makensis": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/makensis/-/makensis-3.0.5.tgz",
+      "integrity": "sha512-DMu+L+kRQiSeIt7qHwtjb2HkpIatPfbEsRFQpyT95aQozLxy2IgOcvzUufOWnVhVXTgRUMlg3E4Gy2vUhNrzRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nsis/language-data": "^0.11.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "deboa": "^1.2.0"
+    "deboa": "^1.2.0",
+    "makensis": "^3.0.5"
   }
 }

--- a/targets/nsis/index.js
+++ b/targets/nsis/index.js
@@ -1,0 +1,21 @@
+const logger = require("../../utils/logger");
+const { validateNsis } = require("./nsisvalidator");
+const { buildPackage } = require("./packagebuilder");
+
+async function build(config, stagingPath) {
+    let packagePath;
+    try {
+        logger.info("NSIS: Starting NSIS packaging...");
+        validateNsis(config);
+        packagePath = await buildPackage(config, stagingPath);
+        logger.info(`NSIS: Generated installer: ${packagePath}`);
+    } catch (error) {
+        console.error(error);
+        throw error;
+    }
+    return packagePath;
+}
+
+module.exports = {
+    build
+};

--- a/targets/nsis/nsisvalidator.js
+++ b/targets/nsis/nsisvalidator.js
@@ -1,0 +1,91 @@
+const fs = require("fs");
+const path = require("path");
+const logger = require("../../utils/logger");
+
+function resolveAssetPath(assetPath) {
+    if (!assetPath) {
+        return null;
+    }
+
+    const normalizedPath = assetPath.trim();
+    const candidates = [];
+
+    if (path.isAbsolute(normalizedPath)) {
+        candidates.push(normalizedPath);
+    }
+
+    candidates.push(
+        path.resolve(
+            process.cwd(),
+            normalizedPath.replace(/^\/+/, "")
+        )
+    );
+
+    return candidates.find(fs.existsSync) || candidates[0];
+}
+
+function validateMetadata(config) {
+    if (!config.metadata) {
+        throw new Error("NsisValidator: Missing metadata configuration.");
+    }
+    if (!config.metadata.applicationId) {
+        throw new Error("NsisValidator: metadata.applicationId is required.");
+    }
+}
+
+function validateAssets(config) {
+    const assets = config.assets || {};
+
+    const requiredAssets = ["icon"];
+    const optionalAssets = ["license", "sidebarImage", "headerImage"];
+
+    for (const assetName of requiredAssets) {
+        const assetPath = assets[assetName];
+
+        if (!assetPath) {
+            throw new Error(`NsisValidator: Required asset '${assetName}' is missing.`);
+        }
+
+        const resolvedPath = resolveAssetPath(assetPath);
+
+        if (!fs.existsSync(resolvedPath)) {
+            throw new Error(`NsisValidator: Required asset '${assetName}' not found: ${resolvedPath}`);
+        }
+
+        logger.info(`NsisValidator: Required asset '${assetName}' found: ${resolvedPath}.`);
+        assets[assetName] = resolvedPath;
+    }
+
+    for (const assetName of optionalAssets) {
+        const assetPath = assets[assetName];
+
+        if (!assetPath) {
+            continue;
+        }
+
+        const resolvedPath = resolveAssetPath(assetPath);
+
+        if (!fs.existsSync(resolvedPath)) {
+            logger.warn(`NsisValidator: Optional asset '${assetName}' not found: ${resolvedPath}. Skipping.`);
+            assets[assetName] = null;
+            continue;
+        }
+
+        logger.info(`NsisValidator: Optional asset '${assetName}' found: ${resolvedPath}.`);
+        assets[assetName] = resolvedPath;
+    }
+
+    config.assets = assets;
+}
+
+function validateNsis(config) {
+    logger.info("NVAL: Validating NSIS configuration...");
+    validateMetadata(config);
+    validateAssets(config);
+    logger.info("NsisValidator: NSIS configuration validated.");
+    return config;
+}
+
+module.exports = {
+    validateNsis
+};

--- a/targets/nsis/packagebuilder.js
+++ b/targets/nsis/packagebuilder.js
@@ -1,0 +1,99 @@
+const fs = require("fs");
+const path = require("path");
+const fileUtils = require("../../utils/fileutils");
+const logger = require("../../utils/logger");
+const makensisProvider = require("./providers/makensis");
+
+function sanitizeAppName(name) {
+    return String(name || "Neutralino Application").trim();
+}
+
+function findBinaryFile(stagingPath) {
+    const files = fs.readdirSync(stagingPath);
+
+    const binaryFile = files.find((file) => {
+        if (file === "resources.neu" || file.endsWith(".nsi")) {
+            return false;
+        }
+        const fullPath = path.join(stagingPath, file);
+        return fs.statSync(fullPath).isFile();
+    });
+
+    if (!binaryFile) {
+        throw new Error("PackageBuilder: Unable to locate Neutralino binary.");
+    }
+
+    return binaryFile;
+}
+
+function buildOptionalBlock(directive, assetPath) {
+    if (!assetPath) {
+        return "";
+    }
+    return `${directive} "${assetPath}"`;
+}
+
+async function buildPackage(config, stagingPath) {
+    const metadata = config.metadata || {};
+    const assets = config.assets || {};
+
+    const appName = sanitizeAppName(metadata.applicationName);
+    const binaryName = findBinaryFile(stagingPath);
+
+    const outputDir = path.resolve(
+        process.cwd(),
+        config.paths?.output || "./dist/windows"
+    );
+    fileUtils.ensureDirectory(outputDir);
+
+    for (const file of fs.readdirSync(outputDir)) {
+        if (file.endsWith(".exe")) {
+            fs.rmSync(path.join(outputDir, file), { force: true });
+        }
+    }
+
+    const outputFile = path.join(outputDir, `${appName}-setup.exe`);
+
+    const hasResources = fs.existsSync(path.join(stagingPath, "resources.neu"));
+
+    const scriptTemplate = fileUtils.readTemplate("nsis/installer.nsi");
+
+    const script = fileUtils.replacePlaceholders(scriptTemplate, {
+        APP_NAME: appName,
+        APP_ID: metadata.applicationId,
+        OUTPUT_FILE: outputFile,
+        ICON_PATH: assets.icon,
+        BINARY_PATH: path.join(stagingPath, binaryName),
+        BINARY_NAME: binaryName,
+        RESOURCES_LINE: hasResources
+            ? `File "${path.join(stagingPath, "resources.neu")}"`
+            : "",
+        SIDEBAR_BLOCK: buildOptionalBlock(
+            "!define MUI_WELCOMEFINISHPAGE_BITMAP",
+            assets.sidebarImage
+        ),
+        HEADER_BLOCK: buildOptionalBlock(
+            "!define MUI_HEADERIMAGE_BITMAP",
+            assets.headerImage
+        ),
+        LICENSE_BLOCK: assets.license
+            ? `!insertmacro MUI_PAGE_LICENSE "${assets.license}"`
+            : ""
+    });
+
+    const scriptPath = path.join(stagingPath, "installer.nsi");
+    fileUtils.writeFile(scriptPath, script);
+
+    logger.info("PackageBuilder: Compiling NSIS installer...");
+    await makensisProvider.compileInstaller(scriptPath, { verbose: 2 });
+
+    if (!fs.existsSync(outputFile)) {
+        throw new Error("PackageBuilder: Installer was not generated.");
+    }
+
+    return outputFile;
+}
+
+module.exports = {
+    buildPackage
+};

--- a/targets/nsis/providers/makensis.js
+++ b/targets/nsis/providers/makensis.js
@@ -1,0 +1,21 @@
+const logger = require("../../../utils/logger");
+
+async function compileInstaller(scriptPath, options = {}) {
+    const NSIS = await import("makensis");
+
+    try {
+        const output = await NSIS.compile(scriptPath, options);
+        return output;
+    } catch (rejection) {
+        const message = typeof rejection === "string"
+            ? rejection
+            : (rejection?.stderr || rejection?.message || "Unknown makensis failure (binary likely not installed or not on PATH).");
+
+        logger.error("MakensisProvider: Compilation failed.");
+        throw new Error(`MakensisProvider: ${message}`);
+    }
+}
+
+module.exports = {
+    compileInstaller
+};

--- a/templates/nsis/installer.nsi
+++ b/templates/nsis/installer.nsi
@@ -1,0 +1,53 @@
+!include "MUI2.nsh"
+
+Name "{{APP_NAME}}"
+OutFile "{{OUTPUT_FILE}}"
+InstallDir "$PROGRAMFILES64\{{APP_NAME}}"
+RequestExecutionLevel admin
+
+!define MUI_ICON "{{ICON_PATH}}"
+!define MUI_UNICON "{{ICON_PATH}}"
+
+{{SIDEBAR_BLOCK}}
+{{HEADER_BLOCK}}
+{{LICENSE_BLOCK}}
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+Section "Install"
+    SetOutPath "$INSTDIR"
+    File "{{BINARY_PATH}}"
+    {{RESOURCES_LINE}}
+
+    CreateDirectory "$SMPROGRAMS\{{APP_NAME}}"
+    CreateShortcut "$SMPROGRAMS\{{APP_NAME}}\{{APP_NAME}}.lnk" "$INSTDIR\{{BINARY_NAME}}"
+    CreateShortcut "$DESKTOP\{{APP_NAME}}.lnk" "$INSTDIR\{{BINARY_NAME}}"
+
+    WriteUninstaller "$INSTDIR\uninstall.exe"
+
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\{{APP_ID}}" \
+        "DisplayName" "{{APP_NAME}}"
+    WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\{{APP_ID}}" \
+        "UninstallString" "$INSTDIR\uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+    Delete "$INSTDIR\{{BINARY_NAME}}"
+    Delete "$INSTDIR\resources.neu"
+    Delete "$INSTDIR\uninstall.exe"
+    RMDir "$INSTDIR"
+
+    Delete "$SMPROGRAMS\{{APP_NAME}}\{{APP_NAME}}.lnk"
+    RMDir "$SMPROGRAMS\{{APP_NAME}}"
+    Delete "$DESKTOP\{{APP_NAME}}.lnk"
+
+    DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\{{APP_ID}}"
+SectionEnd


### PR DESCRIPTION
****
Implements Task 3 (Windows NSIS installer).
****
Added:
- targets/nsis/index.js - main build entry point
- targets/nsis/nsisvalidator.js - validates metadata and 
  required/optional assets (icon, license, sidebar, header)
- targets/nsis/packagebuilder.js - generates the NSIS script 
  from template and invokes makensis
- targets/nsis/providers/makensis.js - wraps the npm makensis 
  package (ESM-only, loaded via dynamic import)
- templates/nsis/installer.nsi - NSIS script template with 
  placeholders for app name, icon, binary, optional assets
****
Fixed lib/stagingmanager.js:
- neu build nests all platform binaries together in 
  dist/<appname>/, not directly in dist/. Updated to detect 
  the correct app folder (via resources.neu presence) and 
  filter binaries by config.targetPlatform, since multiple 
  platform binaries legitimately coexist in the same folder.
****
Tested end-to-end with real makensis (v3.12) against a real 
neu build output - successfully generates a working Windows 
.exe installer with icon, shortcuts, and uninstaller support.