### PR TITLE
feat: Added launcher script for debian to simulate a symlink

### DIFF
--- a/constants/configschema.js
+++ b/constants/configschema.js
@@ -23,7 +23,8 @@ const resolvedConfig = {
         version: null,
         maintainer: null,
         category: null,
-        description: null
+        description: null,
+        resolvedBinaryName: null
     },
     paths: {
         output: null

--- a/lib/configresolver.js
+++ b/lib/configresolver.js
@@ -116,6 +116,7 @@ function resolveConfig(
         description:
             targetConfig.description || "Neutralino Application",
 
+        resolvedBinaryName: null
     };
     finalConfig.paths = {
         output:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "dependencies": {
         "chalk": "^4.1.2",
         "deboa": "^1.2.0"
-      },
-      "bin": {
-        "neu-builder": "index.js"
       }
     },
     "node_modules/agent-base": {

--- a/targets/deb/index.js
+++ b/targets/deb/index.js
@@ -2,10 +2,10 @@ const logger = require("../../utils/logger");
 
 const buildPackage = require("./packagebuilder");
 
-const {
-    prepareDebLayout,
-    validateDebLayout,
-} = require("./staginglayout");
+// const {
+//     prepareDebLayout,
+//     validateDebLayout,
+// } = require("./staginglayout");
 
 const {
     validateDeb
@@ -16,8 +16,8 @@ async function build(config, stagingPath) {
     try {
         logger.info("DEB: Starting DEB packaging...");
         validateDeb(config);
-        prepareDebLayout(config, stagingPath);
-        validateDebLayout(config, stagingPath);
+        // prepareDebLayout(config, stagingPath);
+        // validateDebLayout(config, stagingPath);
         packagePath = await buildPackage(config, stagingPath);
         logger.info(`DEB: Generated package: ${packagePath}`);
     } catch (error) {

--- a/targets/deb/index.js
+++ b/targets/deb/index.js
@@ -2,11 +2,6 @@ const logger = require("../../utils/logger");
 
 const buildPackage = require("./packagebuilder");
 
-// const {
-//     prepareDebLayout,
-//     validateDebLayout,
-// } = require("./staginglayout");
-
 const {
     validateDeb
 } = require("./debvalidator");
@@ -16,8 +11,6 @@ async function build(config, stagingPath) {
     try {
         logger.info("DEB: Starting DEB packaging...");
         validateDeb(config);
-        // prepareDebLayout(config, stagingPath);
-        // validateDebLayout(config, stagingPath);
         packagePath = await buildPackage(config, stagingPath);
         logger.info(`DEB: Generated package: ${packagePath}`);
     } catch (error) {

--- a/targets/deb/packagebuilder.js
+++ b/targets/deb/packagebuilder.js
@@ -69,11 +69,8 @@ async function buildPackage(config, stagingPath) {
         controlFileOptions: {
             packageName,
             version: metadata.version || "1.0.0",
-            maintainer:
-                metadata.maintainer || "Unknown",
-            shortDescription:
-                metadata.description ||
-                "Neutralino Application",
+            maintainer: metadata.maintainer,
+            shortDescription: metadata.description
         },
 
         beforePackage: async (tempDir) => {
@@ -105,26 +102,13 @@ async function buildPackage(config, stagingPath) {
         },
 
         beforeCreateDesktopEntry: (entry) => {
-            entry.Name =
-                metadata.applicationName ||
-                packageName;
-
-            entry.GenericName =
-                metadata.applicationName ||
-                packageName;
-
-            entry.Comment =
-                metadata.description || "";
-
+            entry.Name = metadata.applicationName || packageName;
+            entry.GenericName = metadata.applicationName || packageName;
+            entry.Comment = metadata.description;
             entry.Exec = launcherName;
-
             entry.Icon = packageName;
-
-            entry.Categories =
-                metadata.category || "Utility";
-
+            entry.Categories = metadata.category;
             entry.Terminal = false;
-
             return entry;
         },
 
@@ -133,10 +117,7 @@ async function buildPackage(config, stagingPath) {
                 header.name
             );
 
-            if (
-                basename === executableName ||
-                basename === launcherName
-            ) {
+            if (basename === executableName || basename === launcherName) {
                 header.mode = 0o755;
             }
 

--- a/targets/deb/packagebuilder.js
+++ b/targets/deb/packagebuilder.js
@@ -1,53 +1,47 @@
 const fs = require("fs");
 const path = require("path");
 
-const deboaProvider =
-    require("./providers/deboa");
+const deboaProvider = require("./providers/deboa");
 
 function sanitizePackageName(name) {
-    return String(name || "neutralino-app")
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9.+-]/g, "-")
-        .replace(/-+/g, "-")
-        .replace(/^[.-]+|[.-]+$/g, "") || "neutralino-app";
+    return (
+        String(name || "neutralino-app")
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9.+-]/g, "-")
+            .replace(/-+/g, "-")
+            .replace(/^[.-]+|[.-]+$/g, "") ||
+        "neutralino-app"
+    );
 }
 
 async function buildPackage(config, stagingPath) {
+    const metadata = config.metadata || {};
 
-    const metadata =
-        config.metadata || {};
+    const packageName = sanitizePackageName(
+        metadata.applicationId
+    );
 
-    const packageName =
-        sanitizePackageName(
-            metadata.applicationId
-        );
+    const launcherName = sanitizePackageName(
+        metadata.applicationName || packageName
+    );
 
     const outputDir = path.resolve(
         process.cwd(),
-        config.paths?.output ||
-        "./dist/linux"
+        config.paths?.output || "./dist/linux"
     );
 
-    fs.mkdirSync(
-        outputDir,
-        { recursive: true }
-    );
+    fs.mkdirSync(outputDir, { recursive: true });
 
     for (const file of fs.readdirSync(outputDir)) {
         if (file.endsWith(".deb")) {
-            fs.rmSync(
-                path.join(
-                    outputDir,
-                    file
-                ),
-                { force: true }
-            );
+            fs.rmSync(path.join(outputDir, file), {
+                force: true,
+            });
         }
     }
 
-    const executableName =
-        metadata.resolvedBinaryName;
+    const executableName = metadata.resolvedBinaryName;
 
     if (!executableName) {
         throw new Error(
@@ -55,77 +49,102 @@ async function buildPackage(config, stagingPath) {
         );
     }
 
-    const outputFile =
-        await deboaProvider.createPackage({
-            sourceDir: stagingPath,
-            targetDir: outputDir,
-            installationRoot: `/opt/${packageName}`,
-            icon: config.assets?.icon || undefined,
-            controlFileOptions: {
-                packageName,
-                version: metadata.version || "1.0.0",
-                maintainer: metadata.maintainer || "Unknown",
-                shortDescription: metadata.description || "Neutralino Application",
-            },
-            beforeCreateDesktopEntry:
-                (entry) => {
-                    entry.Name = metadata.applicationName || packageName;
-                    entry.GenericName = metadata.applicationName || packageName;
-                    entry.Comment = metadata.description || "";
-                    entry.Exec = `/bin/sh -c "cd /opt/${packageName} && ./${executableName}"`;
-                    entry.Icon = packageName;
-                    entry.Categories = metadata.category || "Utility";
-                    entry.Terminal = false;
-                    return entry;
-                },
+    const executablePath = path.join(
+        stagingPath,
+        executableName
+    );
 
-            // TODO: ADD SYMLINK LATER. Handle it later or remove this. But keeping this for reference.
-            // additionalTarEntries: [
-            //     {
-            //         gname: "root",
-            //         uname: "root",
-            //         type: "symlink",
-            //         mode: parseInt(
-            //             "777",
-            //             8
-            //         ),
-            //         linkname: `../../opt/${packageName}/${executableName}`,
-            //         name:`usr/bin/${executableName}`
-            //     }
-            // ],
+    if (!fs.existsSync(executablePath)) {
+        throw new Error(
+            `PackageBuilder: Executable not found: ${executablePath}`
+        );
+    }
 
-            modifyTarHeader:
-                (header) => {
+    const outputFile = await deboaProvider.createPackage({
+        sourceDir: stagingPath,
+        targetDir: outputDir,
+        installationRoot: `/opt/${packageName}`,
+        icon: config.assets?.icon,
 
-                    if (
-                        path.basename(
-                            header.name
-                        ) === executableName
-                    ) {
-                        header.mode =
-                            parseInt(
-                                "0755",
-                                8
-                            );
-                    }
+        controlFileOptions: {
+            packageName,
+            version: metadata.version || "1.0.0",
+            maintainer:
+                metadata.maintainer || "Unknown",
+            shortDescription:
+                metadata.description ||
+                "Neutralino Application",
+        },
 
-                    return header;
-                }
-        });
+        beforePackage: async (tempDir) => {
+            const usrBin = path.join(
+                tempDir,
+                "usr",
+                "bin"
+            ); fs.mkdirSync(usrBin, {
+                recursive: true,
+            });
 
-    const stats = fs.statSync(outputFile);
+            const launcherPath = path.join(
+                usrBin,
+                launcherName
+            );
 
-    // TODO: Handle it later or remove this. But keeping this for reference.
-    // Temp fix/workaround for Deboa odd-size archive issue
-    // if (stats.size % 2 !== 0) {
-    //     fs.appendFileSync(
-    //         outputFile,
-    //         "\n"
-    //     );
-    // }
+            fs.writeFileSync(
+                launcherPath,
+                `#!/bin/sh
+                cd /opt/${packageName}
+                exec ./${executableName} "$@"
+                `
+            );
+
+            fs.chmodSync(
+                launcherPath,
+                0o755
+            );
+        },
+
+        beforeCreateDesktopEntry: (entry) => {
+            entry.Name =
+                metadata.applicationName ||
+                packageName;
+
+            entry.GenericName =
+                metadata.applicationName ||
+                packageName;
+
+            entry.Comment =
+                metadata.description || "";
+
+            entry.Exec = launcherName;
+
+            entry.Icon = packageName;
+
+            entry.Categories =
+                metadata.category || "Utility";
+
+            entry.Terminal = false;
+
+            return entry;
+        },
+
+        modifyTarHeader: (header) => {
+            const basename = path.basename(
+                header.name
+            );
+
+            if (
+                basename === executableName ||
+                basename === launcherName
+            ) {
+                header.mode = 0o755;
+            }
+
+            return header;
+        },
+    });
 
     return outputFile;
 }
 
-module.exports =
-    buildPackage;
+module.exports = buildPackage;

--- a/targets/deb/providers/deboa.js
+++ b/targets/deb/providers/deboa.js
@@ -11,7 +11,8 @@ async function createPackage(options) {
         icon: options.icon,
         controlFileOptions: options.controlFileOptions,
         beforeCreateDesktopEntry: options.beforeCreateDesktopEntry,
-        modifyTarHeader: options.modifyTarHeader
+        modifyTarHeader: options.modifyTarHeader,
+        beforePackage: options.beforePackage
     });
 
     await deboa.package();


### PR DESCRIPTION
closes #15 

Initially implemented a ``/usr/bin symlink`` to the packaged executable in ``/opt``. The symlink itself worked correctly, but Neutralino expects ``resources.neu`` to be available relative to the process's working directory. When the application was launched through the ``symlink``, it searched for ``/usr/bin/resources.neu`` instead of the packaged resources in ``/opt/<package>``, causing the runtime to fail. 

This PR adds a launcher script lets us set the working directory before executing the binary, so the application behaves correctly whether it's launched from the desktop or the terminal.