### PR TITLE
feat: add npm publish workflow and scope

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish Package to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Publish Package
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neutralinojs-builder",
+  "name": "@neutralinojs-contrib/builder",
   "version": "1.0.0",
   "description": "A standalone Neutralinojs CLI plugin for packaging and installer generation",
   "main": "index.js",


### PR DESCRIPTION
Adds NPM publish CD workflow for neu-builder.

- Added .github/workflows/publish.yml to automatically 
  publish to npm on GitHub release
- Updated package name to @neutralinojs-contrib/builder 
  to match the new official npm org