### PR TITLE
feat: Added Debian packaging maintainer scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
-
+installerassets*
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/constants/configschema.js
+++ b/constants/configschema.js
@@ -25,6 +25,12 @@ const resolvedConfig = {
         category: null,
         description: null
     },
+    maintainerScripts: {
+        preinst: null,
+        postinst: null,
+        prerm: null,
+        postrm: null
+    },
     paths: {
         output: null
     }

--- a/lib/configresolver.js
+++ b/lib/configresolver.js
@@ -117,6 +117,12 @@ function resolveConfig(
             targetConfig.description || "Neutralino Application",
 
     };
+    finalConfig.maintainerScripts = {
+        preinst: targetConfig.preinst || null,
+        postinst: targetConfig.postinst || null,
+        prerm: targetConfig.prerm || null,
+        postrm: targetConfig.postrm || null
+    }
     finalConfig.paths = {
         output:
             targetConfig.output

--- a/neutralino.config.json
+++ b/neutralino.config.json
@@ -34,7 +34,11 @@
             "icon": "./installerassets/linux/deb/app.png",
             "category": "Utility",
             "output": "./dist/linux",
-            "maintainer": "GSoC"
+            "maintainer": "GSoC",
+            "preinst": "./installerassets/linux/deb/scripts/preinst", 
+            "postinst": "./installerassets/linux/deb/scripts/postinst", 
+            "prerm": "./installerassets/linux/deb/scripts/prerm", 
+            "postrm": "./installerassets/linux/deb/scripts/postrm"
           },
           {
             "target": "appimage",

--- a/targets/deb/debvalidator.js
+++ b/targets/deb/debvalidator.js
@@ -99,11 +99,46 @@ function validateAssets(config) {
     config.assets = assets;
 }
 
+function validateMaintainerScripts(config) {
+
+    const scripts = config.maintainerScripts || {};
+
+    const optionalScripts = [
+        "preinst",
+        "postinst",
+        "prerm",
+        "postrm"
+    ];
+
+    for (const scriptName of optionalScripts) {
+
+        const scriptPath = scripts[scriptName];
+
+        if (!scriptPath) {
+            continue;
+        }
+
+        const resolvedPath = resolveAssetPath(scriptPath);
+
+        if (!fs.existsSync(resolvedPath)) {
+            logger.warn(`DebValidator: Optional maintainer script '${scriptName}' not found: ${resolvedPath}. Skipping.`);
+            scripts[scriptName] = null;
+            continue;
+        }
+        logger.info(`DebValidator: Optional maintainer script '${scriptName}' found: ${resolvedPath}.`);
+        scripts[scriptName] = resolvedPath;
+    }
+
+    config.maintainerScripts = scripts;
+}
+
+
 function validateDeb(config) {
 
     logger.info("DVAL: Validating DEB configuration...");
     validateMetadata(config);
     validateAssets(config);
+    validateMaintainerScripts(config);
     logger.info("DebValidator: DEB configuration validated.");
     return config;
 }

--- a/targets/deb/packagebuilder.js
+++ b/targets/deb/packagebuilder.js
@@ -54,7 +54,10 @@ async function buildPackage(config, stagingPath) {
             "PackageBuilder: Missing metadata.resolvedBinaryName"
         );
     }
-
+    const maintainerScripts = Object.fromEntries(
+        Object.entries(config.maintainerScripts || {})
+            .filter(([, scriptPath]) => scriptPath)
+    );
     const outputFile =
         await deboaProvider.createPackage({
             sourceDir: stagingPath,
@@ -66,6 +69,9 @@ async function buildPackage(config, stagingPath) {
                 version: metadata.version || "1.0.0",
                 maintainer: metadata.maintainer || "Unknown",
                 shortDescription: metadata.description || "Neutralino Application",
+                ...(Object.keys(maintainerScripts).length > 0 && {
+                    maintainerScripts
+                })
             },
             beforeCreateDesktopEntry:
                 (entry) => {


### PR DESCRIPTION
This PR adds maintainer scripts such as ``prerm``, ``postrm``, ``postinst`` and ``preinst``. These scripts are treated as optional assets if any of them are provided only then they are used otherwise they are ignore.

 

